### PR TITLE
[FEAT-5] 지도 전체조회 기능 추가 

### DIFF
--- a/src/main/java/com/dnd/dndtravel/map/controller/MapController.java
+++ b/src/main/java/com/dnd/dndtravel/map/controller/MapController.java
@@ -1,0 +1,21 @@
+package com.dnd.dndtravel.map.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dnd.dndtravel.map.service.MapService;
+import com.dnd.dndtravel.map.service.dto.response.RegionResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class MapController {
+
+	private final MapService mapService;
+
+	@GetMapping("/map/all")
+	public RegionResponse map() {
+		return mapService.allRegions();
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/map/controller/MapController.java
+++ b/src/main/java/com/dnd/dndtravel/map/controller/MapController.java
@@ -14,7 +14,7 @@ public class MapController {
 
 	private final MapService mapService;
 
-	@GetMapping("/map/all")
+	@GetMapping("/maps")
 	public RegionResponse map() {
 		return mapService.allRegions();
 	}

--- a/src/main/java/com/dnd/dndtravel/map/domain/Opacity.java
+++ b/src/main/java/com/dnd/dndtravel/map/domain/Opacity.java
@@ -1,0 +1,9 @@
+package com.dnd.dndtravel.map.domain;
+
+public enum Opacity {
+	ZERO, ONE, TWO, THREE;
+
+	public boolean isNotZero() {
+		return this != ZERO;
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/map/domain/Opacity.java
+++ b/src/main/java/com/dnd/dndtravel/map/domain/Opacity.java
@@ -1,9 +1,19 @@
 package com.dnd.dndtravel.map.domain;
 
 public enum Opacity {
-	ZERO, ONE, TWO, THREE;
+	ZERO(0), ONE(1), TWO(2), THREE(3);
+
+	private final int value;
+
+	Opacity(int value) {
+		this.value = value;
+	}
 
 	public boolean isNotZero() {
 		return this != ZERO;
+	}
+
+	public int toInt() {
+		return this.value;
 	}
 }

--- a/src/main/java/com/dnd/dndtravel/map/domain/Region.java
+++ b/src/main/java/com/dnd/dndtravel/map/domain/Region.java
@@ -22,18 +22,18 @@ public class Region {
 	private String name; // 지역 이름
 
 	@Enumerated(EnumType.STRING)
-	private Opacity opacity; // 방문 횟수(색의 opacity)
+	private VisitOpacity visitOpacity; // 방문 횟수(색의 opacity)
 
-	public static Region of(String name, Opacity opacity) {
-		return new Region(name, opacity);
+	public static Region of(String name, VisitOpacity visitOpacity) {
+		return new Region(name, visitOpacity);
 	}
 
 	public boolean isVisited() {
-		return opacity.isNotZero();
+		return visitOpacity.isNotZero();
 	}
 
-	private Region(String name, Opacity opacity) {
+	private Region(String name, VisitOpacity visitOpacity) {
 		this.name = name;
-		this.opacity = opacity;
+		this.visitOpacity = visitOpacity;
 	}
 }

--- a/src/main/java/com/dnd/dndtravel/map/domain/Region.java
+++ b/src/main/java/com/dnd/dndtravel/map/domain/Region.java
@@ -1,0 +1,39 @@
+package com.dnd.dndtravel.map.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Region {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name; // 지역 이름
+
+	@Enumerated(EnumType.STRING)
+	private Opacity opacity; // 방문 횟수(색의 opacity)
+
+	public static Region of(String name, Opacity opacity) {
+		return new Region(name, opacity);
+	}
+
+	public boolean isVisited() {
+		return opacity.isNotZero();
+	}
+
+	private Region(String name, Opacity opacity) {
+		this.name = name;
+		this.opacity = opacity;
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/map/domain/VisitOpacity.java
+++ b/src/main/java/com/dnd/dndtravel/map/domain/VisitOpacity.java
@@ -1,11 +1,11 @@
 package com.dnd.dndtravel.map.domain;
 
-public enum Opacity {
+public enum VisitOpacity {
 	ZERO(0), ONE(1), TWO(2), THREE(3);
 
 	private final int value;
 
-	Opacity(int value) {
+	VisitOpacity(int value) {
 		this.value = value;
 	}
 

--- a/src/main/java/com/dnd/dndtravel/map/repository/MapRepository.java
+++ b/src/main/java/com/dnd/dndtravel/map/repository/MapRepository.java
@@ -1,0 +1,8 @@
+package com.dnd.dndtravel.map.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dnd.dndtravel.map.domain.Region;
+
+public interface MapRepository extends JpaRepository<Region, Long> {
+}

--- a/src/main/java/com/dnd/dndtravel/map/service/MapService.java
+++ b/src/main/java/com/dnd/dndtravel/map/service/MapService.java
@@ -1,0 +1,34 @@
+package com.dnd.dndtravel.map.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dnd.dndtravel.map.domain.Region;
+import com.dnd.dndtravel.map.repository.MapRepository;
+import com.dnd.dndtravel.map.service.dto.RegionDto;
+import com.dnd.dndtravel.map.service.dto.response.RegionResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class MapService {
+
+	private final MapRepository mapRepository;
+
+	@Transactional(readOnly = true)
+	public RegionResponse allRegions() {
+		List<Region> all = mapRepository.findAll();
+
+		List<RegionDto> regions = all.stream()
+			.map(RegionDto::from)
+			.toList();
+		int visitCount = (int)all.stream()
+			.filter(Region::isVisited)
+			.count();
+
+		return new RegionResponse(regions, visitCount);
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/map/service/dto/RegionDto.java
+++ b/src/main/java/com/dnd/dndtravel/map/service/dto/RegionDto.java
@@ -8,6 +8,6 @@ public record RegionDto(
 ) {
 
 	public static RegionDto from(Region region) {
-		return new RegionDto(region.getName(), region.getOpacity().toInt());
+		return new RegionDto(region.getName(), region.getVisitOpacity().toInt());
 	}
 }

--- a/src/main/java/com/dnd/dndtravel/map/service/dto/RegionDto.java
+++ b/src/main/java/com/dnd/dndtravel/map/service/dto/RegionDto.java
@@ -1,14 +1,13 @@
 package com.dnd.dndtravel.map.service.dto;
 
-import com.dnd.dndtravel.map.domain.Opacity;
 import com.dnd.dndtravel.map.domain.Region;
 
 public record RegionDto(
 	String name,
-	Opacity opacity
+	int opacity
 ) {
 
 	public static RegionDto from(Region region) {
-		return new RegionDto(region.getName(), region.getOpacity());
+		return new RegionDto(region.getName(), region.getOpacity().toInt());
 	}
 }

--- a/src/main/java/com/dnd/dndtravel/map/service/dto/RegionDto.java
+++ b/src/main/java/com/dnd/dndtravel/map/service/dto/RegionDto.java
@@ -1,0 +1,14 @@
+package com.dnd.dndtravel.map.service.dto;
+
+import com.dnd.dndtravel.map.domain.Opacity;
+import com.dnd.dndtravel.map.domain.Region;
+
+public record RegionDto(
+	String name,
+	Opacity opacity
+) {
+
+	public static RegionDto from(Region region) {
+		return new RegionDto(region.getName(), region.getOpacity());
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/map/service/dto/response/RegionResponse.java
+++ b/src/main/java/com/dnd/dndtravel/map/service/dto/response/RegionResponse.java
@@ -6,6 +6,13 @@ import com.dnd.dndtravel.map.service.dto.RegionDto;
 
 public record RegionResponse(
 	List<RegionDto> regions,
-	int visitCount
+	int visitCount,
+	int totalCount
 ) {
+
+	private static final int TOTAL_COUNT = 16; // 전체 지역구의 개수, 변경가능성이 낮아 16이라는 상수로 고정
+
+	public RegionResponse(List<RegionDto> regions, int visitCount) {
+		this(regions, visitCount, TOTAL_COUNT);
+	}
 }

--- a/src/main/java/com/dnd/dndtravel/map/service/dto/response/RegionResponse.java
+++ b/src/main/java/com/dnd/dndtravel/map/service/dto/response/RegionResponse.java
@@ -1,0 +1,11 @@
+package com.dnd.dndtravel.map.service.dto.response;
+
+import java.util.List;
+
+import com.dnd.dndtravel.map.service.dto.RegionDto;
+
+public record RegionResponse(
+	List<RegionDto> regions,
+	int visitCount
+) {
+}

--- a/src/test/java/com/dnd/dndtravel/map/controller/MapControllerTest.java
+++ b/src/test/java/com/dnd/dndtravel/map/controller/MapControllerTest.java
@@ -1,0 +1,33 @@
+package com.dnd.dndtravel.map.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dnd.dndtravel.map.service.MapService;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@WebMvcTest(MapController.class)
+class MapControllerTest {
+
+	@MockBean
+	private MapService mapService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void 전체_지역정보를_조회한다() throws Exception {
+		// when & then
+		mockMvc.perform(get("/map/all"))
+			.andExpect(status().isOk());
+	}
+
+}

--- a/src/test/java/com/dnd/dndtravel/map/service/MapServiceTest.java
+++ b/src/test/java/com/dnd/dndtravel/map/service/MapServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.dnd.dndtravel.map.domain.Opacity;
+import com.dnd.dndtravel.map.domain.VisitOpacity;
 import com.dnd.dndtravel.map.domain.Region;
 import com.dnd.dndtravel.map.repository.MapRepository;
 import com.dnd.dndtravel.map.service.dto.response.RegionResponse;
@@ -52,23 +52,23 @@ class MapServiceTest {
 
 			// 모든 지역이 방문되지 않은 경우
 			Arguments.of(List.of(
-				Region.of("서울특별시", Opacity.ZERO),
-				Region.of("부산", Opacity.ZERO),
-				Region.of("충청도", Opacity.ZERO)
+				Region.of("서울특별시", VisitOpacity.ZERO),
+				Region.of("부산", VisitOpacity.ZERO),
+				Region.of("충청도", VisitOpacity.ZERO)
 			), 0, 3),
 
 			// 모든 지역이 방문된 경우
 			Arguments.of(List.of(
-				Region.of("서울특별시", Opacity.ONE),
-				Region.of("부산", Opacity.ONE),
-				Region.of("충청도", Opacity.ONE)
+				Region.of("서울특별시", VisitOpacity.ONE),
+				Region.of("부산", VisitOpacity.ONE),
+				Region.of("충청도", VisitOpacity.ONE)
 			), 3, 3),
 
 			// 일부 지역만 방문된 경우
 			Arguments.of(List.of(
-				Region.of("서울특별시", Opacity.ONE),
-				Region.of("부산", Opacity.ZERO),
-				Region.of("충청도", Opacity.ONE)
+				Region.of("서울특별시", VisitOpacity.ONE),
+				Region.of("부산", VisitOpacity.ZERO),
+				Region.of("충청도", VisitOpacity.ONE)
 			), 2, 3)
 		);
 	}

--- a/src/test/java/com/dnd/dndtravel/map/service/MapServiceTest.java
+++ b/src/test/java/com/dnd/dndtravel/map/service/MapServiceTest.java
@@ -1,0 +1,48 @@
+package com.dnd.dndtravel.map.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.dndtravel.map.domain.Opacity;
+import com.dnd.dndtravel.map.domain.Region;
+import com.dnd.dndtravel.map.repository.MapRepository;
+import com.dnd.dndtravel.map.service.dto.response.RegionResponse;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class MapServiceTest {
+
+	@InjectMocks
+	private MapService sut;
+
+	@Mock
+	private MapRepository mapRepository;
+
+	@Test
+	void 전체_지역정보를_조회한다() {
+		// given
+		List<Region> mockRegions = List.of(
+			Region.of("서울특별시", Opacity.TWO),
+			Region.of("부산", Opacity.ZERO),
+			Region.of("충청도", Opacity.THREE)
+		);
+		given(mapRepository.findAll()).willReturn(mockRegions);
+
+		// when
+		RegionResponse actual = sut.allRegions();
+
+		// then
+		assertThat(actual.regions().size()).isEqualTo(3);
+		assertThat(actual.visitCount()).isEqualTo(2);
+	}
+}


### PR DESCRIPTION
## What is this PR? :mag:
- 온보딩 후 홈 화면의 지도 전체조회 기능 구현 
- 지역 도메인엔티티 추가

## Changes :memo:
현재까지의 Controller Test는 크게 의미있는 테스트 같아 보이지 않아서 조금더 생각해봐야합니다. 

## Screenshot :camera:

응답 형식 
![image](https://github.com/user-attachments/assets/fd714aad-ae30-42f7-91b9-e9aa3a11b030)
