### PR TITLE
인증객체 ,ArgumentResolver추가

### DIFF
--- a/src/main/java/com/dnd/dndtravel/auth/service/JwtProvider.java
+++ b/src/main/java/com/dnd/dndtravel/auth/service/JwtProvider.java
@@ -42,4 +42,21 @@ public class JwtProvider {
             .signWith(Keys.hmacShaKeyFor(Base64.getDecoder().decode(this.secretKey)))
             .compact();
     }
+
+    public Claims parseClaims(String splitHeader) {
+        Jws<Claims> claims;
+        try {
+            claims = Jwts.parser()
+                    .verifyWith(Keys.hmacShaKeyFor(Base64.getDecoder().decode(this.secretKey)))
+                    .build()
+                    .parseSignedClaims(splitHeader);
+
+        } catch (ExpiredJwtException e) {
+            throw new RuntimeException("message", e); // 유효하지 않은 토큰
+        } catch (JwtException e) {
+            throw new RuntimeException("message", e); // 토큰 해독 실패
+        }
+
+        return claims.getPayload();
+    }
 }

--- a/src/main/java/com/dnd/dndtravel/config/AuthResolver.java
+++ b/src/main/java/com/dnd/dndtravel/config/AuthResolver.java
@@ -1,0 +1,57 @@
+package com.dnd.dndtravel.config;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.dnd.dndtravel.auth.service.JwtProvider;
+import com.dnd.dndtravel.member.domain.Member;
+import com.dnd.dndtravel.member.repository.MemberRepository;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthResolver implements HandlerMethodArgumentResolver {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String MEMBER_ID_CLAIM = "memberId";
+	private static final String BEARER_PREFIX = "Bearer";
+	private final MemberRepository memberRepository;
+	private final JwtProvider jwtProvider;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.getParameterType().equals(AuthenticationMember.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+		// 헤더 자체가 비어있는 경우
+		String header = webRequest.getHeader(AUTHORIZATION_HEADER);
+		if (header == null || header.isEmpty()) {
+			throw new RuntimeException("토큰이 없음");
+		}
+
+		String[] splitHeaders = header.split(" ");
+
+		//<Bearer> <token> 형식이 아닌경우
+		if (splitHeaders.length != 2 || !BEARER_PREFIX.equals(splitHeaders[0])) {
+			throw new RuntimeException("유효하지 않은 토큰 형식");
+		}
+
+		//토큰 까봐서 만료,조작여부 확인
+		Claims accessClaim = jwtProvider.parseClaims(splitHeaders[1]);
+
+		//토큰에 심었던 user 식별자값 유효성 확인
+		Member member = memberRepository.findById((Long)accessClaim.get(MEMBER_ID_CLAIM))
+			.orElseThrow(() -> new RuntimeException("유효하지 않은 토큰 값"));
+
+		// 컨트롤러 파라미터로 반환
+		return new AuthenticationMember(member.getId());
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/config/AuthenticationMember.java
+++ b/src/main/java/com/dnd/dndtravel/config/AuthenticationMember.java
@@ -1,0 +1,6 @@
+package com.dnd.dndtravel.config;
+
+public record AuthenticationMember(
+	long id
+) {
+}

--- a/src/main/java/com/dnd/dndtravel/config/WebMvcConfig.java
+++ b/src/main/java/com/dnd/dndtravel/config/WebMvcConfig.java
@@ -1,0 +1,25 @@
+package com.dnd.dndtravel.config;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.dnd.dndtravel.auth.service.JwtProvider;
+import com.dnd.dndtravel.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final MemberRepository memberRepository;
+	private final JwtProvider jwtProvider;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new AuthResolver(memberRepository, jwtProvider));
+	}
+}


### PR DESCRIPTION
## What is this PR? :mag:
* spring security에 비해 익숙하고 간단한 ArgumentResolver로 구현

## Screenshot :camera:
![image](https://github.com/user-attachments/assets/d1694518-a718-4b3f-9c49-c6a29716482f)

위와같이 컨트롤러 parameter에 resolver에 등록한 객체(AuthenticationMember)가 있는경우 해당 메서드 실행전에 resolver가 실행되고 Member에대한 정보를 컨트롤러로 반환