### PR TITLE
#41 Swagger Update

### DIFF
--- a/src/main/java/com/dnd/dndtravel/auth/controller/request/AppleWithdrawRequest.java
+++ b/src/main/java/com/dnd/dndtravel/auth/controller/request/AppleWithdrawRequest.java
@@ -1,5 +1,8 @@
 package com.dnd.dndtravel.auth.controller.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -7,8 +10,9 @@ import jakarta.validation.constraints.Size;
 클라이언트에서 서버로 보내는 요청
  */
 public record AppleWithdrawRequest(
-        @NotBlank(message = "인증 코드가 존재하지 않습니다.")
-        @Size(max = 300, message = "인증 코드 길이를 초과하였습니다.")
+        @Schema(description = "authorization code", requiredMode = REQUIRED)
+        @NotBlank(message = "authorization code는 필수 입니다.")
+        @Size(max = 300, message = "authorization code 형식이 아닙니다.")
         String authorizationCode
 ) {
 }

--- a/src/main/java/com/dnd/dndtravel/auth/controller/swagger/AuthControllerSwagger.java
+++ b/src/main/java/com/dnd/dndtravel/auth/controller/swagger/AuthControllerSwagger.java
@@ -1,5 +1,7 @@
 package com.dnd.dndtravel.auth.controller.swagger;
 
+import com.dnd.dndtravel.auth.controller.request.AppleWithdrawRequest;
+import com.dnd.dndtravel.config.AuthenticationMember;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
@@ -63,5 +65,29 @@ public interface AuthControllerSwagger {
 	ReissueTokenResponse reissueToken(
 		@Parameter(description = "refreshToken", required = true)
 		ReIssueTokenRequest reissueTokenRequest
+	);
+
+	@Operation(
+			summary = "애플 회원 탈퇴 API"
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "정상적으로 탈퇴 되었습니다."),
+			@ApiResponse(responseCode = "400", description = "인증 실패 또는 유효하지 않은 요청",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(example = STATUS_CODE_400_BODY_MESSAGE)
+					)
+			),
+			@ApiResponse(
+					responseCode = "500", description = "서버 오류",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(example = "{\"message\":\"Internal Server Error\"}")
+					)
+			)
+	})
+	void withdraw(
+			@Parameter(description = "요청 정보(authorization code)", required = true)
+					AppleWithdrawRequest appleWithdrawRequest,
+			@Parameter(hidden = true)
+					AuthenticationMember authenticationMember
 	);
 }

--- a/src/main/java/com/dnd/dndtravel/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/dndtravel/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.dnd.dndtravel.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,6 +17,26 @@ public class SwaggerConfig {
                 .info(new Info()
                         .title("MAPDDANG API")
                         .description("맵땅 앱 관련 API")
-                        .version("1.0.0"));
+                        .version("1.0.0"))
+                .addSecurityItem(new SecurityRequirement()
+                        .addList("Access Token")
+                        .addList("Refresh Token"))
+                .components(new Components()
+                        .addSecuritySchemes("Access Token", createAccessTokenScheme())
+                        .addSecuritySchemes("Refresh Token", createRefreshTokenScheme()));
+    }
+
+    private SecurityScheme createAccessTokenScheme() {
+        return new SecurityScheme().type(SecurityScheme.Type.HTTP)
+                .bearerFormat("JWT")
+                .scheme("bearer")
+                .description("Access Token");
+    }
+
+    private SecurityScheme createRefreshTokenScheme() {
+        return new SecurityScheme().type(SecurityScheme.Type.HTTP)
+                .bearerFormat("JWT")
+                .scheme("bearer")
+                .description("Refresh Token");
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:
- 회원 탈퇴 API Docs 작성
- Swagger UI의 Authorize 기능 추가
## Changes :memo:
Swagger UI에 "Authorize" 버튼이 나타나며, 사용자는 이 버튼을 통해 JWT 토큰을 입력할 수 있습니다. 입력된 토큰은 이후의 API 요청에 자동으로 포함되어 편리한 API 테스트가 가능합니다.
## Screenshot :camera:
예)Bearer + " " + token 값
의 형식으로 넣고 Authorize 버튼을 누르면 HTTP 요청의 헤더에 해당 토큰 값이 포함됩니다.

![image](https://github.com/user-attachments/assets/95702a97-8518-4284-a026-f4861dbb935d)

서버, 클라이언트 측 모두 편리하게 쓸 수 있는 것이라 생각해 적용해 보았습니다!
도움이 되지 않는다고 생각하시면 🔥 하겠습니다 ㅎㅎ .
