### PR TITLE
#45 Server URL 설정

### DIFF
--- a/src/main/java/com/dnd/dndtravel/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/dndtravel/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,6 +19,7 @@ public class SwaggerConfig {
                         .title("MAPDDANG API")
                         .description("맵땅 앱 관련 API")
                         .version("1.0.0"))
+                .addServersItem(new Server().url("/").description("Generated Default Server URL")) //local에서는 http, aws에서는 https로 server url 설정됨
                 .addSecurityItem(new SecurityRequirement()
                         .addList("Access Token")
                         .addList("Refresh Token"))


### PR DESCRIPTION
## What is this PR? :mag:
Swagger에서 API 요청 시 request url과 실제 운영 서버 url이 달라서 Failed to fetch 오류 발생
## Changes :memo:
- SwaggerConfig에서 server url 설정
https://mapddng.site 로 넣어도 되지만, localhost에서 실행 시 또 url이 달라서 안되기 때문에 자동으로 서버 url을 따라 가도록 수정
## Screenshot :camera:
![image](https://github.com/user-attachments/assets/d462be74-07cb-4873-953e-c114b930e592)
