### PR TITLE
[#57] 탈퇴 후 재로그인 문제 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.1.0'
 
     //OpenFeign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3'

--- a/src/main/java/com/dnd/dndtravel/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/dndtravel/auth/controller/AuthController.java
@@ -43,12 +43,15 @@ public class AuthController implements AuthControllerSwagger {
     }
 
     @PostMapping("/reissue/token")
-    public ReissueTokenResponse reissueToken(@RequestBody ReIssueTokenRequest reissueTokenRequest) {
+    public ReissueTokenResponse reissueToken(@RequestBody @Valid ReIssueTokenRequest reissueTokenRequest) {
         return jwtTokenService.reIssue(reissueTokenRequest.refreshToken());
     }
 
     @DeleteMapping("/withdraw")
-    public void withdraw(@Valid @RequestBody AppleWithdrawRequest withdrawRequest, AuthenticationMember authenticationMember) {
+    public void withdraw(
+        @RequestBody @Valid AppleWithdrawRequest withdrawRequest,
+        AuthenticationMember authenticationMember
+    ) {
         // 1. Apple 서버에서 Access Token 받아오기
         String accessToken = appleOAuthService.getAccessToken(withdrawRequest.authorizationCode());
 

--- a/src/main/java/com/dnd/dndtravel/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/dndtravel/auth/controller/AuthController.java
@@ -1,19 +1,14 @@
 package com.dnd.dndtravel.auth.controller;
 
-import java.util.Optional;
-
 import com.dnd.dndtravel.auth.controller.request.AppleWithdrawRequest;
 import com.dnd.dndtravel.auth.controller.request.ReIssueTokenRequest;
 import com.dnd.dndtravel.auth.controller.swagger.AuthControllerSwagger;
-import com.dnd.dndtravel.auth.service.AppleOAuthService;
+import com.dnd.dndtravel.auth.service.AuthService;
 import com.dnd.dndtravel.auth.service.JwtTokenService;
 import com.dnd.dndtravel.auth.controller.request.AppleLoginRequest;
-import com.dnd.dndtravel.auth.service.dto.response.AppleTokenResponse;
 import com.dnd.dndtravel.auth.service.dto.response.TokenResponse;
 import com.dnd.dndtravel.auth.service.dto.response.ReissueTokenResponse;
 import com.dnd.dndtravel.config.AuthenticationMember;
-import com.dnd.dndtravel.member.domain.Member;
-import com.dnd.dndtravel.member.service.MemberService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,22 +19,14 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RestController
 public class AuthController implements AuthControllerSwagger {
-    private final AppleOAuthService appleOAuthService;
+    private final AuthService authService;
     private final JwtTokenService jwtTokenService;
-    private final MemberService memberService;
 
     @PostMapping("/login/oauth2/apple")
-    public ResponseEntity<TokenResponse> appleOAuthLogin(@RequestBody @Valid AppleLoginRequest appleLoginRequest) {
-        // idToken 정보와 애플의 RefreshToken 얻기위해 Apple API 호출
-        AppleTokenResponse appleTokenResponse = appleOAuthService.get(appleLoginRequest.authorizationCode());
-
-        Member member = memberService.saveMember(
-            appleTokenResponse.email(),
-            appleTokenResponse.sub(),
-            appleLoginRequest.selectedColor()
-        );
-
-        return generateTokenResponse(appleTokenResponse.appleRefreshToken(), member.getId());
+    public ResponseEntity<TokenResponse> appleOAuthLogin(@RequestBody @Valid AppleLoginRequest request) {
+        return authService.processAppleLogin(request.authorizationCode(), request.selectedColor())
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.noContent().build());
     }
 
     @PostMapping("/reissue/token")
@@ -52,21 +39,6 @@ public class AuthController implements AuthControllerSwagger {
         @RequestBody @Valid AppleWithdrawRequest withdrawRequest,
         AuthenticationMember authenticationMember
     ) {
-        // 1. Apple 서버에서 Access Token 받아오기
-        String accessToken = appleOAuthService.getAccessToken(withdrawRequest.authorizationCode());
-
-        // 2. Apple 서버에 탈퇴 요청
-        appleOAuthService.revoke(accessToken);
-
-        // 3. 자체 회원 탈퇴 진행
-        memberService.withdrawMember(authenticationMember.id());
-    }
-
-    private ResponseEntity<TokenResponse> generateTokenResponse(String appleRefreshToken, Long memberId) {
-        TokenResponse tokenResponse = jwtTokenService.generateTokens(memberId, appleRefreshToken);
-
-        return Optional.ofNullable(tokenResponse)
-            .map(ResponseEntity::ok)
-            .orElse(ResponseEntity.noContent().build());
+        authService.processAppleRevoke(withdrawRequest.refreshToken(), authenticationMember.id());
     }
 }

--- a/src/main/java/com/dnd/dndtravel/auth/controller/request/AppleLoginRequest.java
+++ b/src/main/java/com/dnd/dndtravel/auth/controller/request/AppleLoginRequest.java
@@ -13,7 +13,7 @@ public record AppleLoginRequest(
 	@Schema(description = "authorization code", requiredMode = REQUIRED)
 	@NotBlank(message = "authorization code는 필수 입니다.")
 	@Size(max = 300, message = "authorization code 형식이 아닙니다")
-	String appleToken,
+	String authorizationCode,
 
 	@Schema(description = "유저가 선택한 색상", requiredMode = REQUIRED)
 	@ColorValidation(enumClass = SelectedColor.class)

--- a/src/main/java/com/dnd/dndtravel/auth/controller/request/AppleWithdrawRequest.java
+++ b/src/main/java/com/dnd/dndtravel/auth/controller/request/AppleWithdrawRequest.java
@@ -6,13 +6,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-/*
-클라이언트에서 서버로 보내는 요청
- */
 public record AppleWithdrawRequest(
-        @Schema(description = "authorization code", requiredMode = REQUIRED)
-        @NotBlank(message = "authorization code는 필수 입니다.")
-        @Size(max = 300, message = "authorization code 형식이 아닙니다.")
-        String authorizationCode
+        @Schema(description = "애플 refreshToken", requiredMode = REQUIRED)
+        @NotBlank(message = "refreshToken은 필수 입니다.")
+        @Size(max = 300, message = "refreshToken 형식이 아닙니다.")
+        String refreshToken
 ) {
 }

--- a/src/main/java/com/dnd/dndtravel/auth/controller/request/ReIssueTokenRequest.java
+++ b/src/main/java/com/dnd/dndtravel/auth/controller/request/ReIssueTokenRequest.java
@@ -1,6 +1,15 @@
 package com.dnd.dndtravel.auth.controller.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record ReIssueTokenRequest(
+	@Schema(description = "refresh token", requiredMode = REQUIRED)
+	@NotBlank(message = "refresh token은 필수 입니다.")
+	@Size(max = 300, message = "refresh token 형식이 아닙니다.")
 	String refreshToken
 ) {
 }

--- a/src/main/java/com/dnd/dndtravel/auth/controller/request/ReIssueTokenRequest.java
+++ b/src/main/java/com/dnd/dndtravel/auth/controller/request/ReIssueTokenRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record ReIssueTokenRequest(
-	@Schema(description = "refresh token", requiredMode = REQUIRED)
+	@Schema(description = "mapddang refresh token", requiredMode = REQUIRED)
 	@NotBlank(message = "refresh token은 필수 입니다.")
 	@Size(max = 300, message = "refresh token 형식이 아닙니다.")
 	String refreshToken

--- a/src/main/java/com/dnd/dndtravel/auth/exception/RequireReAuthenticationException.java
+++ b/src/main/java/com/dnd/dndtravel/auth/exception/RequireReAuthenticationException.java
@@ -1,0 +1,9 @@
+package com.dnd.dndtravel.auth.exception;
+
+public class RequireReAuthenticationException extends RuntimeException {
+	private static final String MESSAGE = "Apple 계정 재인증이 필요합니다.";
+
+	public RequireReAuthenticationException(Exception e) {
+		super(MESSAGE, e);
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/dndtravel/auth/service/AuthService.java
@@ -1,0 +1,39 @@
+package com.dnd.dndtravel.auth.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.dnd.dndtravel.auth.service.dto.response.AppleTokenResponse;
+import com.dnd.dndtravel.auth.service.dto.response.TokenResponse;
+import com.dnd.dndtravel.member.domain.Member;
+import com.dnd.dndtravel.member.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthService {
+	private final AppleOAuthService appleOAuthService;
+	private final MemberService memberService;
+	private final JwtTokenService jwtTokenService;
+
+	public Optional<TokenResponse> processAppleLogin(String authorizationCode, String selectedColor) {
+		AppleTokenResponse appleToken = appleOAuthService.get(authorizationCode);
+
+		Member member = memberService.saveMember(
+			appleToken.email(),
+			appleToken.sub(),
+			selectedColor
+		);
+
+		return Optional.ofNullable(
+			jwtTokenService.generateTokens(member.getId(), appleToken.appleRefreshToken())
+		);
+	}
+
+	public void processAppleRevoke(String refreshToken, long memberId) {
+		appleOAuthService.revoke(refreshToken);
+		memberService.withdrawMember(memberId);
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/auth/service/dto/response/AppleTokenResponse.java
+++ b/src/main/java/com/dnd/dndtravel/auth/service/dto/response/AppleTokenResponse.java
@@ -1,0 +1,17 @@
+package com.dnd.dndtravel.auth.service.dto.response;
+
+public record AppleTokenResponse(
+	String sub,
+	String name,
+	String email,
+	String appleRefreshToken
+) {
+	public static AppleTokenResponse of(AppleIdTokenPayload appleIdTokenPayload, String appleRefreshToken) {
+		return new AppleTokenResponse(
+			appleIdTokenPayload.sub(),
+			appleIdTokenPayload.name(),
+			appleIdTokenPayload.email(),
+			appleRefreshToken
+		);
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/auth/service/dto/response/TokenResponse.java
+++ b/src/main/java/com/dnd/dndtravel/auth/service/dto/response/TokenResponse.java
@@ -2,6 +2,7 @@ package com.dnd.dndtravel.auth.service.dto.response;
 
 public record TokenResponse(
 	String accessToken,
-	String refreshToken
+	String refreshToken,
+	String appleRefreshToken
 ) {
 }

--- a/src/main/java/com/dnd/dndtravel/map/exception/MemberNotFoundException.java
+++ b/src/main/java/com/dnd/dndtravel/map/exception/MemberNotFoundException.java
@@ -6,4 +6,8 @@ public class MemberNotFoundException extends RuntimeException {
 	public MemberNotFoundException(long memberId) {
 		super(String.format(MESSAGE, memberId));
 	}
+
+	public MemberNotFoundException(String appleId) {
+		super(String.format(MESSAGE, appleId));
+	}
 }

--- a/src/main/java/com/dnd/dndtravel/map/repository/WithdrawMemberRepository.java
+++ b/src/main/java/com/dnd/dndtravel/map/repository/WithdrawMemberRepository.java
@@ -1,0 +1,11 @@
+package com.dnd.dndtravel.map.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dnd.dndtravel.member.domain.WithdrawMember;
+
+public interface WithdrawMemberRepository extends JpaRepository<WithdrawMember, Long> {
+	Optional<WithdrawMember> findByAppleId(String sub);
+}

--- a/src/main/java/com/dnd/dndtravel/member/domain/WithdrawMember.java
+++ b/src/main/java/com/dnd/dndtravel/member/domain/WithdrawMember.java
@@ -1,0 +1,40 @@
+package com.dnd.dndtravel.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = "apple_id")
+	}
+)
+@Entity
+public class WithdrawMember {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String appleId;
+
+	@Column(nullable = false)
+	private String email;
+
+	private WithdrawMember(String appleId) {
+		this.appleId = appleId;
+	}
+
+	public static WithdrawMember of(String appleId) {
+		return new WithdrawMember(appleId);
+	}
+}

--- a/src/main/java/com/dnd/dndtravel/member/service/MemberService.java
+++ b/src/main/java/com/dnd/dndtravel/member/service/MemberService.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class MemberService {
-
     private final MemberRepository memberRepository;
     private final MemberAttractionRepository memberAttractionRepository;
     private final MemberRegionRepository memberRegionRepository;


### PR DESCRIPTION
## Changes :memo:
- WithDrawMember 라는 테이블에 Apple sub값을 저장해 유저의 기존 로그인여부를 확인할 수 있게 개선
- AppleClient 불필요한 호출횟수 감소
- 탈퇴를 위한 Apple의 RefreshToken을 응답값에 추가
- 동작하지 않는 @Valid 동작되도록 수정

## 추가
- 가입한 유저수만큼 WithDrawMember 테이블 크기가 커질 수 있음. 탈퇴후 N일 이상된 유저 정보는 주기적으로 삭제한다거나 하는 방식도 고려해 볼 수 있을것 같습니다
